### PR TITLE
Used hashParams to move token and refresh token to the front end.

### DIFF
--- a/client/components/Search.jsx
+++ b/client/components/Search.jsx
@@ -31,9 +31,36 @@ const Search = () => {
   const [playlistData, setPlaylistData] = useState([])
   const [concerts, setConcerts] = useState([])
   const [spotifyToken, setSpotifyToken] = useState('');
+  const [refreshToken, setRefreshToken] = useState('')
   const [loading, setLoading] = useState(false);
   const [track, setTrack] = useState(['spotify:track:4fSIb4hdOQ151TILNsSEaF']);
   const [placeDisplayType, setPlaceDisplayType] = useState('block')
+
+
+  function getHashParams() {
+    const hashParams = {};
+    let e, r = /([^&;=]+)=?([^&;]*)/g,
+        q = window.location.hash.substring(1);
+    while ( e = r.exec(q)) {
+       hashParams[e[1]] = decodeURIComponent(e[2]);
+    }
+    let access_token = hashParams.access_token;
+    let refresh_token = hashParams.refresh_token;
+    
+    console.log('access_token in search.jsx ', access_token);
+    console.log('refresh_token in search.jsx ', refresh_token);
+
+    setSpotifyToken(access_token);
+    setRefreshToken(refresh_token);
+
+    history.replaceState(null, '', '/')
+  }
+
+  useEffect(( )=> {
+    getHashParams();
+  }, [])
+ 
+
 
 
   useEffect(() => {

--- a/server/controllers/spotifyAuthController.js
+++ b/server/controllers/spotifyAuthController.js
@@ -80,12 +80,11 @@ spotifyAuthController.requestTokens = (req, res, next) => {
 
       res.locals.access_token = access_token;
       res.locals.refresh_token = refresh_token;
-      console.log('access_token: ', access_token);
-      console.log('refresh_token: ', refresh_token);
-      console.log('response.data.expires_in, ', response.data.expires_in);
+      console.log('access_token in spotifyAuthController.requestTokens: ', access_token);
+      console.log('access_token in spotifyAuthController.requestTokens: ', refresh_token);
         
-      res.cookie('access_token', access_token, {maxAge: 3600});
       res.cookie('refresh_token', refresh_token, {maxAge: 2592000}); 
+
       return next();
     } else {
       console.log('This is the response error from spotify: ', response.data.error);
@@ -115,8 +114,8 @@ spotifyAuthController.getUserData = (req, res, next) => {
 }
 
 // This controller uses the refresh token (stored in users cookies) to get a new access token
-spotifyAuthController.exchangeRefreshToken = ((req, res, next) => {
-
+spotifyAuthController.exchangeRefreshToken = (req, res, next) => {
+  // check if req.cookies.refresh_token exists, and if it does invoke this code
     const refresh_token = req.query.refresh_token;
     const options = {
       method: 'POST',
@@ -142,7 +141,7 @@ spotifyAuthController.exchangeRefreshToken = ((req, res, next) => {
     .catch((err) => {
       console.log("error in sporifyAuthController.exchangeRefreshToken, ", err)
     })
-})
+}
 
 
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -3,6 +3,7 @@ const spotifyController = require('../controllers/spotifyController');
 const locationController = require('../controllers/locationController');
 const userController = require('../controllers/userController');
 const spotifyAuthController = require('../controllers/spotifyAuthController')
+const querystring = require('querystring');
 
 // router.post('/signup', controllers.createUser);
 // router.post('/token', controllers.handleToken);
@@ -11,10 +12,14 @@ const spotifyAuthController = require('../controllers/spotifyAuthController')
 // This route handles the second step in the Spotify Authorization Process, and intercepts a call from Spotify as specified in the Spotify For Developers App dashboard
 router.get('/callback', 
   spotifyAuthController.requestTokens,
-  spotifyAuthController.getUserData,
   (req, res) => {
     // TODO: Redirect is currently hardcoded. This should be updated to route to our homepage or search
-    res.redirect('http://localhost:8080');
+    res.redirect('http://localhost:8080#' +
+      querystring.stringify({
+        access_token: res.locals.access_token,
+        refresh_token: res.locals.refresh_token,
+      })
+    );
   }
 )
 


### PR DESCRIPTION
Moved the token from the backend server to frontend in the hash parameters. Decoded and removed the URL from history. This merge should not impact existing token authentication being done through the "authenticate" button in the existing code.